### PR TITLE
Fix erroneous field resolution when equal signs are present in field contents

### DIFF
--- a/zotero_bibtize/zotero_bibtize.py
+++ b/zotero_bibtize/zotero_bibtize.py
@@ -35,7 +35,7 @@ class BibEntry(object):
         field, count = re.subn(r'^(\s*)|(\s*)$', '', field)
         # needs a separate expression for matching months which are
         # not exported with surrounding braces...
-        regex = r'^([\s\S]*)\s+\=\s+(?:\{([\s\S]*)\}|([\s\S]*)),*?$'
+        regex = r'^([\s\S]*?)\s+\=\s+(?:\{([\s\S]*)\}|([\s\S]*)),*?$'
         fmatch = re.match(regex, field)
         field_key = fmatch.group(1)
         field_content = fmatch.group(2) or fmatch.group(3)


### PR DESCRIPTION
fixes #6 

Update regular expression used to match the field name and make it greedy to stop matching at the first occurrence of an equal sign.