### PR TITLE
Add CLI option to define BibTex entries that won't be written to the output file

### DIFF
--- a/tests/zotero_bibtize/test_bibtex_entry.py
+++ b/tests/zotero_bibtize/test_bibtex_entry.py
@@ -182,6 +182,34 @@ def test_field_label_and_contents(empty_bibentry):
     field, content = empty_bibentry.field_label_and_contents(test_string)
     assert field == wanted_field_name
     assert content == wanted_field_content
+
+
+def test_ignore_custom_fields():
+    from zotero_bibtize.zotero_bibtize import BibEntry
+    input_entry = (
+        "@bibtextype{bibkey,",
+        "    field1 = {contents of field 1},",
+        "    field2 = {contents of field 2},",
+        "    field3 = {¢ontents of field 3}",
+        "}",
+        "",  # account for additional newline to separate entries
+    )
+    input_entry = "\n".join(input_entry)
+    # check for one field
+    ignore_fields = "field1"
+    bibentry = BibEntry(input_entry, omit_fields=ignore_fields)
+    assert "field1" not in bibentry.fields.keys()
+    assert "field2" in bibentry.fields.keys()
+    assert "field3" in bibentry.fields.keys()
+    # check for multiple fields
+    ignore_fields = "field1,field3"  # string defined by CLI
+    bibentry = BibEntry(input_entry, omit_fields=ignore_fields)
+    assert "field1" not in bibentry.fields.keys()
+    assert "field1" not in bibentry.fields.keys()
+    assert "field2" in bibentry.fields.keys()
+    
+
+
     
 
 

--- a/zotero_bibtize/cli.py
+++ b/zotero_bibtize/cli.py
@@ -57,5 +57,5 @@ def zotero_bibtize(input_file, output_file, key_format, omit_fields):
         bib_out = output_path
     # read in and write processed contents back
     bibliography = BibTexFile(str(bib_in), key_format, omit_fields)
-    with open(bib_out, 'w') as bib_out_file:
+    with open(str(bib_out), 'w') as bib_out_file:
         bib_out_file.write(''.join(map(str, bibliography.entries)))

--- a/zotero_bibtize/cli.py
+++ b/zotero_bibtize/cli.py
@@ -16,7 +16,12 @@ from zotero_bibtize import BibTexFile
 @click.option('--key-format', required=False, default=None,
               help=("Format key to generate custom bibtex keys, for instance "
                     "[author:capitalize][journal:capitalize:abbreviate][year]"))
-def zotero_bibtize(input_file, output_file, key_format):
+@click.option('--omit-fields', required=False, default=None,
+              help=("Define a list of BibTex fields as comma separated list, "
+                    "i.e. field1,field2,field3,..., that will not be written "
+                    "to the output file"))
+            
+def zotero_bibtize(input_file, output_file, key_format, omit_fields):
     """
     Transform Zotero BibTex files to LaTeX friendly representation.
 
@@ -51,6 +56,6 @@ def zotero_bibtize(input_file, output_file, key_format):
             shutil.copyfile(bib_in, bib_backup)
         bib_out = output_path
     # read in and write processed contents back  
-    bibliography = BibTexFile(str(bib_in), key_format)
+    bibliography = BibTexFile(str(bib_in), key_format, omit_fields)
     with open(bib_out, 'w') as bib_out_file:
         bib_out_file.write(''.join(map(str, bibliography.entries)))

--- a/zotero_bibtize/zotero_bibtize.py
+++ b/zotero_bibtize/zotero_bibtize.py
@@ -8,7 +8,11 @@ from zotero_bibtize.bibkey_formatter import KeyFormatter
 
 
 class BibEntry(object):
-    def __init__(self, bibtex_entry_string, key_format=None):
+    def __init__(self, bibtex_entry_string, key_format=None, omit_fields=None):
+        # check for fields not required
+        self.fields_to_omit = []
+        if omit_fields is not None:
+            self.fields_to_omit = omit_fields.split(',')
         self._raw = bibtex_entry_string
         entry_type, entry_key, entry_fields = self.entry_fields(self._raw)
         # set internal variables
@@ -27,6 +31,8 @@ class BibEntry(object):
         fields = {}
         for field in econtent:
             key, content = self.field_label_and_contents(field)
+            # skip if field was set to be omitted
+            if key in self.fields_to_omit: continue 
             fields[key] = content
         return etype, ekey, fields
 
@@ -113,12 +119,13 @@ class BibEntry(object):
 
 class BibTexFile(object):
     """Bibtext file contents"""
-    def __init__(self, bibtex_file, key_format=None):
+    def __init__(self, bibtex_file, key_format=None, omit_fields=None):
         self.bibtex_file = bibtex_file
         self.entries = []
         self.key_map = collections.defaultdict(list)
         for (index, entry) in enumerate(self.parse_bibtex_entries()):
-            bibentry = BibEntry(entry, key_format=key_format)
+            bibentry = BibEntry(entry, key_format=key_format, 
+                                omit_fields=omit_fields)
             self.entries.append(bibentry)
             self.key_map[bibentry.key].append(index)
         self.resolve_unambiguous_keys()


### PR DESCRIPTION
Adds a new option `--omit-fields` to the `zotero-bibtize` command line utility. This option allows the user to define a comma separated list of BibTex fields that will be ignored by `zotero-bibtize`, i.e. every field defined will not be written to the output file.