### PR TITLE
Fix removal of function words from journal titles

### DIFF
--- a/tests/bibkey_formatter/test_bibkey_formatter.py
+++ b/tests/bibkey_formatter/test_bibkey_formatter.py
@@ -113,3 +113,25 @@ def test_function_words_removal():
     expected_string = (r"climbing image nudged elastic band method "
                         "finding saddle points minimum energy paths")
     assert title == expected_string
+
+
+def test_function_words_removal_for_journals():
+    """
+    For Journals function keys should not match at the end of strings to
+    preserve 'A' in journal names like Journal of Materials Chemistry A
+    or Physical Review A, etc.
+    """
+    key_formatter = KeyFormatter({})
+    journal_string = "Journal of Materials Chemistry A"
+    # test behavior if is_journal is not set
+    string_no_journal = key_formatter.remove_function_words(journal_string)
+    assert string_no_journal == "Journal Materials Chemistry"
+    # test behavior if is_journal is set
+    string_is_journal = key_formatter.remove_function_words(journal_string,
+                                                            is_journal=True)
+    assert string_is_journal == "Journal Materials Chemistry A"
+    # assert 'a' inside the journal name is removed
+    journal_string = "Chemistry A European Journal"
+    string_is_journal = key_formatter.remove_function_words(journal_string,
+                                                            is_journal=True)
+    assert string_is_journal == "Chemistry European Journal"

--- a/zotero_bibtize/bibkey_formatter.py
+++ b/zotero_bibtize/bibkey_formatter.py
@@ -90,10 +90,10 @@ class KeyFormatter(object):
         curly_braces_regex = r"[\{\}]"
         return re.sub(curly_braces_regex, '', content_string).strip()
 
-    def remove_function_words(self, content_string):
+    def remove_function_words(self, content_string, is_journal=False):
         """Remove all function words from the given string."""
         # a list of function words as defined by JabRef
-        # (cf. https://docs.jabref.org/setup/bibtexkeypatterns)
+        # (cf. https://docs.jabref.org/setup/bibtexkeypatterns)=False
         function_words_list =  [
             "a", "an", "the", "above", "about", "across", "against", "along", 
             "among", "around", "at", "before", "behind", "below", "beneath", 
@@ -106,6 +106,11 @@ class KeyFormatter(object):
         # join single words with regex 'or' operator
         function_words = "|".join(function_words_list)
         word_regex = r"(?i)(?:^|(?<=\s))({})(?:(?=\s)|$)".format(function_words)
+        # for journals do not match at the end of the string which would remove
+        # 'A' from journal names like Journal of Materials Chemistry A or
+        # Physical Review A
+        if is_journal:
+            word_regex = r"(?i)(?:^|(?<=\s))({})(?:(?=\s))".format(function_words)
         content_string = re.sub(word_regex, '', content_string).strip()
         # remove consecutive whitespaces
         content_string = re.sub(r"\s+", " ", content_string)
@@ -160,7 +165,7 @@ class KeyFormatter(object):
                                 "the journal key format")
         journal = self.remove_latex_content(journal)
         journal = re.sub(r"[^[A-Za-z0-9\s]", '', journal)
-        journal = self.remove_function_words(journal)
+        journal = self.remove_function_words(journal, is_journal=True)
         journal_list = journal.split(' ')
         for format_arg in format_args:
             journal_list = self.apply_format_to_content(journal_list, 


### PR DESCRIPTION
When removing function keys from journal names such keys will also be removed from the end of journal titles, in particular, journal names like `Journal of Materials Chemistry A` are affected and are changed to `Journal Materials Chemistry` which is not desirable. In this fix an addtional flag `is_journal` is introduced. If this flag is set to true function words will not be matched at the end of a string. However, function words inside the string will still be removed.